### PR TITLE
small change to _bspExtCatchBreakpoint as EXC_DAR was unused in the new exception frame

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OBJS=$(C_O_FILES) $(CC_O_FILES) $(S_O_FILES)
 include $(RTEMS_MAKEFILE_PATH)/Makefile.inc
 
 include $(RTEMS_CUSTOM)
-include $(RTEMS_ROOT)/make/lib.cfg
+include $(RTEMS_SHARE_PATH)/make/lib.cfg
 
 ifneq ($(filter $(RTEMS_CPU),i386 powerpc)xx,xx)
 # this CPU is supported
@@ -42,10 +42,11 @@ ifneq ($(filter $(RTEMS_CPU),i386 powerpc)xx,xx)
 # Add local stuff here using +=
 #
 
-DEFINES  +=
+DEFINES  += -Dmpc7455
 CPPFLAGS +=
 # inline declarations require -O
 CFLAGS   += -Winline
+CFLAGS   += -I/home/rtems/RTEMS/rtems-4.12/powerpc-rtems4.12/beatnik/lib/include
 
 #
 # Add your list of files to delete here.  The config files

--- a/bspExt.h
+++ b/bspExt.h
@@ -54,6 +54,10 @@
 #include <rtems.h>
 #include <bsp.h>
 
+/* for SPR register aliases */
+#include <rtems/powerpc/registers.h>
+#include <libcpu/spr.h>
+
 /* Macro to detect RTEMS version */
 #include <rtems/system.h>
 

--- a/dabrBpnt.c
+++ b/dabrBpnt.c
@@ -204,6 +204,7 @@ bspExtRemoveBreakpoint(void *addr)
 #define PHASE(cause)	((cause)&2)
 #define TYPE(cause)		((cause)&1)
 
+SPR_RO(PPC_DAR)
 
 int
 _bspExtCatchBreakpoint(BSP_Exception_frame *fp)
@@ -216,8 +217,8 @@ int				cause = -1;
 /* check for catch condition */
 	if ( 3==fp->_EXC_number && 
          (BPNTS[DBPNT].mode & DABR_MODE_COARSE ?
-           !(((long)BPNTS[DBPNT].addr ^ (long)fp->EXC_DAR) & ~DABR_FLGS) :
-           (long)BPNTS[DBPNT].addr == (long)fp->EXC_DAR
+           !(((long)BPNTS[DBPNT].addr ^ (long)_read_PPC_DAR) & ~DABR_FLGS) :
+           (long)BPNTS[DBPNT].addr == (long)_read_PPC_DAR
          ) )
 		cause = CAUSE_DABR_PHASE1;
 	else if ( 0x13 == fp->_EXC_number &&


### PR DESCRIPTION
made small changes to _bspExtCatchBreakpoint (dabrBpnt.c) as the EXC_DAR is no more in the exception frame. Tested just with the beatnik board (mpc7455).
